### PR TITLE
Abschnitt mit ungültiger Stimme neu formuliert.

### DIFF
--- a/Protokolle/Versammlungen/MV2019-20191214.tex
+++ b/Protokolle/Versammlungen/MV2019-20191214.tex
@@ -190,9 +190,7 @@ Die zur Wahl stehenden Personen sind:
 
 Die Wahl erfolgt in geheimer Abstimmung.
 
-\subsection*{Ungültige Stimmen}
-
-Eine der abgegebenen Stimmen ist ungültig.
+Eine der abgegebenen Wahlzettel war nicht auswertbar. Die Stimme ist dadurch ungültig und wurde nicht mitgezählt.
 
 \begin{tabularx}{\linewidth}{Xr}
 Abgegebene Stimmen: & 15 \\


### PR DESCRIPTION
Der Teil mit der Abgabe der ungültigen Stimme war unklar formuliert. Ich habe das neu formuliert. So sollte dies klarer sein.